### PR TITLE
/race/レース名と/horse/馬名ページ

### DIFF
--- a/my-app/src/app/api/race/route.ts
+++ b/my-app/src/app/api/race/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
         try {
           const fileContent = fs.readFileSync(path.join(directoryPath, file), 'utf8');
           const fileData = JSON.parse(fileContent);
-          raceData.push(fileData.title);
+          raceData.push(fileData);
         } catch (error) {
           console.error(`ファイル "${file}" の読み込みまたはパース中にエラーが発生しました:`, error);
           throw new Error(`${file} の読み込み中にエラーが発生しました。`);

--- a/my-app/src/app/context/RaceContext.tsx
+++ b/my-app/src/app/context/RaceContext.tsx
@@ -1,0 +1,27 @@
+'use client'
+import { createContext, useState, ReactNode, useContext } from 'react';
+
+interface RaceContextType {
+  races: any[];
+  setRaces: (races: any[]) => void;
+}
+
+const RaceContext = createContext<RaceContextType | undefined>(undefined);
+
+export function useRaceContext() {
+  const context = useContext(RaceContext);
+  if (!context) {
+    throw new Error('useRaceContext must be used within a RaceProvider');
+  }
+  return context;
+}
+
+export function RaceProvider({ children }: { children: ReactNode }) {
+  const [races, setRaces] = useState<any[]>([]);
+
+  return (
+    <RaceContext.Provider value={{ races, setRaces }}>
+      {children}
+    </RaceContext.Provider>
+  );
+}

--- a/my-app/src/app/info/horse/[id]/page.tsx
+++ b/my-app/src/app/info/horse/[id]/page.tsx
@@ -1,0 +1,53 @@
+'use client'
+import { useRaceContext } from "@/app/context/RaceContext";
+import { useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+export default function Race ({params}: {params: {id: number}}) {
+  const { races, setRaces } = useRaceContext();
+  const searchParams = useSearchParams();
+  const horseId = searchParams.get('horseId');
+  const race = races[params.id]
+  const horse = race.horse?.[Number(horseId)]
+  
+  useEffect(() => {
+    const savedRaces = localStorage.getItem('races');
+    if (savedRaces) {
+      setRaces(JSON.parse(savedRaces));
+    }
+  }, [setRaces]);
+
+  useEffect(() => {
+    if (races.length > 0) {
+      localStorage.setItem('races', JSON.stringify(races));
+    }
+  }, [races]);
+  if (!race || !horse) {
+    return <p>該当のレースが見つかりません。</p>;
+  }
+
+  return (
+    <div>
+      <h1>レース情報</h1>
+      <p>レース名:{race.title}</p>
+      <p>{race.course}</p>
+      <a href={race.url}>{race.url}</a>
+      
+      <p>馬名:{horse.horse}</p>
+      <p>着順:{horse.rank}</p>
+      <p>枠:{horse.waku}</p>
+      <p>馬番:{horse.umaban}</p>
+      <p>性齢:{horse.age}</p>
+      <p>負担重量:{horse.weight}</p>
+      <p>騎手名:{horse.jockey}</p>
+      <p>タイム:{horse.time}</p>
+      <p>着差:{horse.margin}</p>
+      <p>コーナー通過順位:{horse.corner[0]}{horse.corner[1]}{horse.corner[2]}{horse.corner[3]}</p>
+      <p>推定上り:{horse.f_time}</p>
+      <p>馬体重:{horse.h_weight}</p>
+      <p>体重増減:{horse.h_weight_zougen}</p>
+      <p>調教師名:{horse.trainer}</p>
+      <p>単勝人気:{horse.pop}</p>
+    </div>
+  )
+};

--- a/my-app/src/app/info/horse/page.tsx
+++ b/my-app/src/app/info/horse/page.tsx
@@ -1,5 +1,8 @@
 'use client'
-import { useState, useEffect } from 'react';
+import { useState, useEffect, AwaitedReactNode, JSXElementConstructor, Key, ReactElement, ReactNode, ReactPortal } from 'react';
+import { useRaceContext } from '@/app/context/RaceContext';
+import { div } from 'framer-motion/client';
+import Link from 'next/link';
 
 interface horse {
   rank?: number;
@@ -20,12 +23,12 @@ interface horse {
 }
 
 export default function Home() {
-  const [races, setRaces] = useState([]);
+  const { races, setRaces } = useRaceContext();
 
   useEffect(() => {
     const fetchRaceData = async () => {
       try {
-        const response = await fetch('/api/horse');
+        const response = await fetch('/api/race');
         if (!response.ok) {
           throw new Error(`HTTPのエラー: ${response.status}`);
         }
@@ -44,9 +47,15 @@ export default function Home() {
     <div>
       <div>
       {races.length > 0 ? (
-          races.map((raceData: horse, index) => (
+          races.map((raceData, index) => (
             <div key={index}>
-              <p>{raceData.horse}</p>
+              {raceData.horse?.map((horseData: { horse: string | number | bigint | boolean | ReactElement<any, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<AwaitedReactNode> | null | undefined; }, horseIndex: Key | null | undefined) => (
+                <div key={horseIndex}>
+                  <Link href={`/info/horse/${index}?horseId=${horseIndex}`}>
+                    {horseData.horse}
+                  </Link>
+                </div>
+              ))}
             </div>
           ))
         ) : (

--- a/my-app/src/app/info/race/[id]/page.tsx
+++ b/my-app/src/app/info/race/[id]/page.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useRaceContext } from "@/app/context/RaceContext";
+import { useEffect } from "react";
+
+export default function Race ({params}: {params: {id: number}}) {
+  const { races, setRaces } = useRaceContext();
+  const race = races[params.id]
+
+  useEffect(() => {
+    const savedRaces = localStorage.getItem('races');
+    if (savedRaces) {
+      setRaces(JSON.parse(savedRaces));
+    }
+  }, [setRaces]);
+
+  useEffect(() => {
+    if (races.length > 0) {
+      localStorage.setItem('races', JSON.stringify(races));
+    }
+  }, [races]);
+  
+  if (!race) {
+    return <p>該当のレースが見つかりません。</p>;
+  }
+
+  return (
+    <div>
+      <h1>レース名:{race.title}</h1>
+      <p>{race.course}</p>
+      <a href={race.url}>{race.url}</a>
+    </div>
+  )
+};

--- a/my-app/src/app/info/race/page.tsx
+++ b/my-app/src/app/info/race/page.tsx
@@ -1,8 +1,11 @@
 'use client'
+import Link from 'next/link';
 import { useState, useEffect } from 'react';
+import { useRaceContext } from '@/app/context/RaceContext';
+
 
 export default function Home() {
-  const [races, setRaces] = useState([]);
+  const { races, setRaces } = useRaceContext();
 
   useEffect(() => {
     const fetchRaceData = async () => {
@@ -28,7 +31,9 @@ export default function Home() {
       {races.length > 0 ? (
           races.map((raceData, index) => (
             <div key={index}>
-              <p>{raceData}</p>
+              <Link href={`/info/race/${index}`}>
+                {raceData.title}
+              </Link>
             </div>
           ))
         ) : (

--- a/my-app/src/app/layout.tsx
+++ b/my-app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { RaceProvider } from "./context/RaceContext";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -28,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <RaceProvider>{children}</RaceProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
ルーティング
・/info/race/[id]
・/info/horse/[id]

レース情報などのデータは配列に格納しているので、それぞれ[id]にインデックスを指定して、細かい情報のページに遷移するようにしました。

opencvとの連携はしていません
