### PR TITLE
馬詳細情報ページを修正

### DIFF
--- a/src/app/info/horse/[name]/page.tsx
+++ b/src/app/info/horse/[name]/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 import { useEffect, useState } from "react"
-import { Activity, ArrowDown, HomeIcon, Link } from "lucide-react";
+import { Activity, ArrowDown, HomeIcon } from "lucide-react";
 import { motion } from "framer-motion";
+import Link from "next/link";
 
 import type { Response } from "@/app/api/horse/route"
 
@@ -88,27 +89,25 @@ export default function Page({ params }: { params: { name: string } }) {
                                 <h2 className="text-3xl font-bold text-white mb-6 text-center">{name}</h2>
                                 {data.map((horse, index) => (
                                     <div key={index}>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-[80px]">
                                             <div className="space-y-4">
                                                 <InfoItem label="レース名" value={horse.title} />
                                                 <InfoItem label="着順" value={horse.rank} />
                                                 <InfoItem label="騎手名" value={horse.jockey} />
                                                 <InfoItem label="調教師名" value={horse.trainer} />
                                                 <InfoItem label="タイム" value={horse.time} />
-                                            </div>
-                                            <div className="space-y-4">
                                                 <InfoItem label="負担重量" value={`${horse.weight}kg`} />
                                                 <InfoItem label="枠" value={horse.waku} />
                                                 <InfoItem label="馬番" value={horse.umaban} />
+                                            </div>
+                                            <div className="space-y-4">
                                                 <InfoItem label="性齢" value={horse.age} />
                                                 <InfoItem label="着差" value={horse.margin} />
                                                 <InfoItem label="コーナー通過順位" value={`${horse.corner.join('-')}`} />
+                                                <InfoItem label="推定上り" value={`${horse.f_time}秒`} />
+                                                <InfoItem label="馬体重" value={`${horse.h_weight}kg (${horse.h_weight_zougen})`} />
+                                                <InfoItem label="単勝人気" value={horse.pop} />
                                             </div>
-                                        </div>
-                                        <div className="mt-8 space-y-4">
-                                            <InfoItem label="推定上り" value={`${horse.f_time}秒`} />
-                                            <InfoItem label="馬体重" value={`${horse.h_weight}kg (${horse.h_weight_zougen})`} />
-                                            <InfoItem label="単勝人気" value={horse.pop} />
                                         </div>
                                     </div>
                                 ))}

--- a/src/app/info/horse/page.tsx
+++ b/src/app/info/horse/page.tsx
@@ -109,8 +109,8 @@ export default function Home() {
                       href={`/info/horse/${horse}`}
                       className="flex items-center p-2 rounded-md  bg-opacity-50 hover:bg-opacity-70 transition-colors duration-200"
                     >
-                      <h3 className="text-xl font-semibold text-white mb-3">{horse}</h3>
-                      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                      <h3 className="text-xl font-semibold text-white mr-3">{horse}</h3>
+                      <div>
                         <p>{data.length}個のレース(この馬が出ている物)を学習済み</p>
                       </div>
                     </Link>


### PR DESCRIPTION
## やったこと
### ・/info/horse/:name
リンクの修正、詳細情報の表示が変になっていたのを修正
<img width="1440" alt="スクリーンショット 2024-11-19 17 25 51" src="https://github.com/user-attachments/assets/19687a3c-2359-4603-8c28-ba4d329a8eca">
<img width="1440" alt="スクリーンショット 2024-11-19 17 26 00" src="https://github.com/user-attachments/assets/29dd12b9-7477-442a-8c7f-a8e31e1a44db">

### ・/info/horse
表示があまり気に入らなかったので勝手に修正しました
<img width="1440" alt="スクリーンショット 2024-11-19 17 25 27" src="https://github.com/user-attachments/assets/6241b036-d456-420f-8cf1-f3f2e222b2d1">

